### PR TITLE
Configure timeout and retries for webhook-caller

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -34,6 +34,12 @@ const mockConfig = async (config) => {
           format: 'simple',
         }
       },
+      makeWebhookProcessorConfig() {
+        return {
+          WEBHOOK_ABORT_TIMEOUT_MS: 10_000,
+          WEBHOOK_MAX_RETRIES: 0,
+        }
+      },
     }
   })
 }

--- a/src/app/module.ts
+++ b/src/app/module.ts
@@ -11,7 +11,11 @@ import { makeJobRunner } from 'lido-nanolib'
 
 import dotenv from 'dotenv'
 
-import { makeConfig, makeLoggerConfig } from '../services/config/service.js'
+import {
+  makeConfig,
+  makeLoggerConfig,
+  makeWebhookProcessorConfig,
+} from '../services/config/service.js'
 import { makeConsensusApi } from '../services/consensus-api/service.js'
 import { makeExecutionApi } from '../services/execution-api/service.js'
 import { makeMetrics, register } from '../services/prom/service.js'
@@ -90,11 +94,9 @@ export const makeAppModule = async () => {
     gsService,
   })
 
-  const webhookProcessor = makeWebhookProcessor(
-    makeRequest([loggerMiddleware(logger), notOkError(), abort(10_000)]),
-    logger,
-    metrics
-  )
+  const webhookConfig = makeWebhookProcessorConfig({ env: process.env })
+
+  const webhookProcessor = makeWebhookProcessor(webhookConfig, logger, metrics)
 
   const messageReloader = makeMessageReloader({
     logger,

--- a/src/services/config/service.ts
+++ b/src/services/config/service.ts
@@ -113,6 +113,20 @@ export const makeLoggerConfig = ({ env }: { env: NodeJS.ProcessEnv }) => {
   return config
 }
 
+export const makeWebhookProcessorConfig = ({
+  env,
+}: {
+  env: NodeJS.ProcessEnv
+}) => {
+  const config = {
+    WEBHOOK_ABORT_TIMEOUT_MS:
+      optional(() => num(env.WEBHOOK_ABORT_TIMEOUT_MS)) ?? 10_000,
+    WEBHOOK_MAX_RETRIES: optional(() => num(env.WEBHOOK_MAX_RETRIES)) ?? 0,
+  }
+
+  return config
+}
+
 const envOrFile = (env: NodeJS.ProcessEnv, envName: string) => {
   if (env[envName]) return env[envName]
 


### PR DESCRIPTION
Adds following configurations for webhook-caller component:

- Make abort timeout for webhook caller
- Optional retries for the webhook caller

This PR makes use of the features present in https://github.com/lidofinance/lido-ts-nanolib/, and so does not need any new packages or explicit retries/abort logic.
