### PR TITLE
feat: add new metric with package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 /messages
 dist
 .jest
+
+/.idea

--- a/src/app/service.ts
+++ b/src/app/service.ts
@@ -5,6 +5,7 @@ export const makeApp = ({
   config,
   logger,
   job,
+  metrics,
   httpHandler,
   executionApi,
   consensusApi,
@@ -18,6 +19,11 @@ export const makeApp = ({
     const version = await appInfoReader.getVersion()
     const mode = config.MESSAGES_LOCATION ? 'message' : 'webhook'
     logger.info(`Validator Ejector v${version} started in ${mode} mode`, config)
+
+    metrics.buildInfo.labels({
+      version,
+      mode,
+    }).inc()
 
     await executionApi.checkSync()
     await consensusApi.checkSync()

--- a/src/app/service.ts
+++ b/src/app/service.ts
@@ -20,10 +20,12 @@ export const makeApp = ({
     const mode = config.MESSAGES_LOCATION ? 'message' : 'webhook'
     logger.info(`Validator Ejector v${version} started in ${mode} mode`, config)
 
-    metrics.buildInfo.labels({
-      version,
-      mode,
-    }).inc()
+    metrics.buildInfo
+      .labels({
+        version,
+        mode,
+      })
+      .inc()
 
     await executionApi.checkSync()
     await consensusApi.checkSync()

--- a/src/services/prom/service.ts
+++ b/src/services/prom/service.ts
@@ -16,6 +16,13 @@ export const makeMetrics = ({
   })
   client.collectDefaultMetrics({ register })
 
+  const buildInfo = new client.Gauge({
+    name: PREFIX + 'build_info',
+    help: 'Build information',
+    labelNames: ['version', 'mode'] as const,
+  })
+  register.registerMetric(buildInfo)
+
   const exitMessages = new client.Counter({
     name: PREFIX + 'exit_messages',
     help: 'Exit messages and their validity: JSON parseability, structure and signature.',
@@ -110,6 +117,7 @@ export const makeMetrics = ({
   }
 
   return {
+    buildInfo,
     exitMessages,
     exitActions,
     eventSecurityVerification,


### PR DESCRIPTION
Add new `build_info` Gauge metric with a version of the app and the working mode in which it is run.