### PR TITLE
docs: add deprecation notes to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # This file is no longer used by semantic-release
 
-For the latest release notes, please see the [GitHub releases page](https://github.com/lidofinance/lido-keys-api/releases).
+For the latest release notes, please see the [GitHub releases page](https://github.com/lidofinance/validator-ejector/releases).
 
 # [1.2.0](https://github.com/lidofinance/validator-ejector/compare/1.1.0...1.2.0) (2023-04-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# This file is no longer used by semantic-release
+
+For the latest release notes, please see the [GitHub releases page](https://github.com/lidofinance/lido-keys-api/releases).
+
 # [1.2.0](https://github.com/lidofinance/validator-ejector/compare/1.1.0...1.2.0) (2023-04-25)
 
 


### PR DESCRIPTION
As the `CHANGELOG.md` file is no longer used to track release notes, the appropriate deprecation notes were added there to reflect this change.