### PR TITLE
feat: expose validator-ejector executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "2.1.0",
   "private": true,
   "main": "index.js",
+  "bin": {
+    "validator-ejector": "dist/src/index.js"
+  },
+  "files": [
+    "dist"
+  ],
   "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-s3": "3.297.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { makeLogger } from './lib/index.js'
 import { makeAppModule } from './app/module.js'
 


### PR DESCRIPTION
- add a package bin entry for validator-ejector
- include the dist directory in packed releases
- add a Node.js shebang to the entry point

This would simplify installation on Nix with `yarnInstallHook` and other tools expecting `bin`:
https://nixos.org/manual/nixpkgs/unstable/#javascript-yarn-v1