### PR TITLE
feat: add JWT support for execution request headers 

### DIFF
--- a/src/app/module.ts
+++ b/src/app/module.ts
@@ -78,7 +78,8 @@ export const makeAppModule = async () => {
   const consistencyChecker = makeConsistencyChecker(
     executionHttp,
     logger,
-    config
+    config,
+    jwtService
   )
 
   const consensusApi = makeConsensusApi(

--- a/src/services/config/config.spec.ts
+++ b/src/services/config/config.spec.ts
@@ -1,4 +1,4 @@
-import { configBase } from '../../test/config.js'
+import { configBase, mockConfig } from '../../test/config.js'
 import {
   makeConfig,
   makeLoggerConfig,
@@ -42,6 +42,14 @@ describe('config module', () => {
       makeConfig({ logger, env: config as unknown as NodeJS.ProcessEnv })
 
     expect(makeConf).not.toThrow()
+  })
+
+  describe('BLOCKS_PRELOAD', () => {
+    test.each(['', '   '])('defaults the blank value %#', (value) => {
+      const config = mockConfig(logger, { BLOCKS_PRELOAD: value })
+
+      expect(config.BLOCKS_PRELOAD).toBe(50000)
+    })
   })
 
   test('invalid optional bool config includes env var name', () => {

--- a/src/services/config/service.ts
+++ b/src/services/config/service.ts
@@ -83,7 +83,10 @@ export const makeConfig = ({
 
     MESSAGES_PASSWORD: optional(() => str(envOrFile(env, 'MESSAGES_PASSWORD'))),
 
-    BLOCKS_PRELOAD: optional(() => num(env.BLOCKS_PRELOAD)) ?? 50000, // 7 days of blocks
+    BLOCKS_PRELOAD: Math.max(
+      1,
+      Math.floor(optional(() => num(env.BLOCKS_PRELOAD)) || 50000)
+    ), // 7 days of blocks
     LOAD_LOGS_STEP: Math.max(
       1,
       Math.floor(optional(() => num(env.LOAD_LOGS_STEP)) || 10000)

--- a/src/services/consistency/consistency.spec.ts
+++ b/src/services/consistency/consistency.spec.ts
@@ -1,10 +1,11 @@
 import nock from 'nock'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ConsistencyChecker, makeConsistencyChecker } from './service.js'
 import { LoggerService, RequestService, makeRequest } from '../../lib/index.js'
 import { mockLogger } from '../../test/logger.js'
 import { mockConfig } from '../../test/config.js'
+import type { JwtService } from '../jwt/service.js'
 
 const elChainIdMock = (hex: string) => ({
   jsonrpc: '2.0',
@@ -70,6 +71,33 @@ describe('makeConsistencyChecker', () => {
       .reply(200, clDepositContractMock('1'))
 
     await expect(checker.checkChainIds()).resolves.toEqual({ chainId: 1 })
+  })
+
+  it('authenticates every EL chain-id request when JWT is configured', async () => {
+    const config = mockConfig(logger, {
+      EXECUTION_NODE: 'http://el-a.example:8545,http://el-b.example:8545',
+      CONSENSUS_NODE: 'http://cl.example:5051',
+      JWT_SECRET_PATH: '/jwt.hex',
+    })
+    const jwtService = {
+      generateToken: vi.fn(() => 'startup-token'),
+    } as unknown as JwtService
+    const checker = makeConsistencyChecker(request, logger, config, jwtService)
+
+    nock('http://el-a.example:8545')
+      .matchHeader('Authorization', 'Bearer startup-token')
+      .post('/')
+      .reply(200, elChainIdMock('0x1'))
+    nock('http://el-b.example:8545')
+      .matchHeader('Authorization', 'Bearer startup-token')
+      .post('/')
+      .reply(200, elChainIdMock('0x1'))
+    nock('http://cl.example:5051')
+      .get('/eth/v1/config/deposit_contract')
+      .reply(200, clDepositContractMock('1'))
+
+    await expect(checker.checkChainIds()).resolves.toEqual({ chainId: 1 })
+    expect(jwtService.generateToken).toHaveBeenCalledTimes(2)
   })
 
   it('throws when EL endpoints report different chain ids', async () => {

--- a/src/services/consistency/service.ts
+++ b/src/services/consistency/service.ts
@@ -7,6 +7,8 @@ import {
   type RequestService,
 } from '../../lib/index.js'
 import type { ConfigService } from '../config/service.js'
+import { createExecutionRequestHeaders } from '../execution-api/service.js'
+import type { JwtService } from '../jwt/service.js'
 
 export type ConsistencyChecker = ReturnType<typeof makeConsistencyChecker>
 
@@ -32,12 +34,17 @@ export const makeConsistencyChecker = (
   {
     EXECUTION_NODE,
     CONSENSUS_NODE,
-  }: Pick<ConfigService, 'EXECUTION_NODE' | 'CONSENSUS_NODE'>
+    JWT_SECRET_PATH,
+  }: Pick<
+    ConfigService,
+    'EXECUTION_NODE' | 'CONSENSUS_NODE' | 'JWT_SECRET_PATH'
+  >,
+  jwtService?: JwtService
 ) => {
   const fetchElChainId = async (url: string): Promise<number> => {
     const res = await request(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: createExecutionRequestHeaders(JWT_SECRET_PATH, jwtService),
       body: JSON.stringify({
         jsonrpc: '2.0',
         method: 'eth_chainId',

--- a/src/services/execution-api/service.ts
+++ b/src/services/execution-api/service.ts
@@ -41,6 +41,24 @@ const isRpcServerError = (json: unknown): boolean => {
 
 export type ExecutionApiService = ReturnType<typeof makeExecutionApi>
 
+export const createExecutionRequestHeaders = (
+  JWT_SECRET_PATH: string | undefined,
+  jwtService?: JwtService
+) => {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+
+  if (JWT_SECRET_PATH && jwtService) {
+    const token = jwtService.generateToken()
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`
+    }
+  }
+
+  return headers
+}
+
 export const makeExecutionApi = (
   request: ReturnType<typeof makeRequest>,
   logger: ReturnType<typeof makeLogger>,
@@ -57,24 +75,9 @@ export const makeExecutionApi = (
   let exitBusAddress: string
   let consensusAddress: string
 
-  const createRequestHeaders = () => {
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    }
-
-    if (JWT_SECRET_PATH && jwtService) {
-      const token = jwtService.generateToken()
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`
-      }
-    }
-
-    return headers
-  }
-
   const elRequest = (requestConfig: RequestConfig) =>
     fallback(async (url) => {
-      const headers = createRequestHeaders()
+      const headers = createExecutionRequestHeaders(JWT_SECRET_PATH, jwtService)
       const res = await request(url, { ...requestConfig, headers })
       const json = await safelyParseJsonResponse(res, logger)
       if (isRpcServerError(json)) {


### PR DESCRIPTION
Fixed two startup blockers:
- JWT authentication is now applied to execution-node chain ID checks.
- Empty BLOCKS_PRELOAD values now use the default instead of producing NaN.